### PR TITLE
Properly respect user wishes for looping property in OpenALListener

### DIFF
--- a/OpenALListener/OpenALListener_DUECA.cxx
+++ b/OpenALListener/OpenALListener_DUECA.cxx
@@ -291,7 +291,8 @@ bool OpenALListener_DUECA::addObjectClassData
 
 bool OpenALListener_DUECA::setLooping(const bool& l)
 {
-  spec.type += " looping";
+  if(l)
+    spec.type += " looping";
   return true;
 }
 


### PR DESCRIPTION
The parameter provided to the DUECA parameter call set-looping was ignored, and looping was always enabled when the call was made. The "looping" property is now only added to the spec if set-looping is called with #t as a parameter.