### PR TITLE
Added option to split the audio recording files and not use a single file

### DIFF
--- a/SoundRecorder/SoundRecorder.hxx
+++ b/SoundRecorder/SoundRecorder.hxx
@@ -78,6 +78,15 @@ private: // simulation data
 
   /** Recording status */
   bool recording;
+
+  /** Specification of recording file */
+  SF_INFO sfinfo;
+
+  /** Use a single file for recording (or open a new one in Advance) */
+  bool single_file;
+
+  /** Previous SimState for detecting state changes */
+  SimulationState prev_SimulationState;
   
 private: // channel access
   /** Information on recording progress */


### PR DESCRIPTION
Original version opened a single audio file at session start and appended all captured audio to it. An option was now added for this behaviour ('single-file', defaults to true), but the user can also choose to not use a single file. In that case, a new audio file will be created, with the given name template, for each transition from HoldCurrent to Advance. If recording in hold is enabled, a new file will also be generated when going from Advance to HoldCurrent. 