### PR TITLE
fixed low-level byte handling error in recorder

### DIFF
--- a/SoundRecorder/SoundRecorder.cxx
+++ b/SoundRecorder/SoundRecorder.cxx
@@ -222,7 +222,7 @@ static void audiocallback(void* mod, Uint8* data, int len)
 void SoundRecorder::cbAudio(Uint8* data, int len)
 {
   sf_count_t count = sf_write_short
-    (sndfile, reinterpret_cast<short int*>(data), len/bytes_per_point);
+    (sndfile, reinterpret_cast<short int*>(data), len/sizeof(short int));
   sample_count += len/bytes_per_point;
 }
 


### PR DESCRIPTION
The audio callback receives the length of the buffers in bytes, not in samples. We need a conversion from number of bytes to number of short ints when writing them to file as short ints, using sizeof. The original version produced choppy, sped up audio files. This one doesn't. 